### PR TITLE
removed codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Build Status](https://travis-ci.org/fossasia/susi_telegrambot.svg?branch=development)](https://travis-ci.org/fossasia/susi_telegrambot)
 [![CircleCI](https://img.shields.io/circleci/project/fossasia/susi_telegrambot.svg?maxAge=2592000?style=flat-square)](https://circleci.com/gh/fossasia/susi_telegrambot)
 [![Code Climate](https://codeclimate.com/github/fossasia/susi_telegrambot/badges/gpa.svg)](https://codeclimate.com/github/fossasia/susi_telegrambot)
-[![codecov](https://codecov.io/gh/fossasia/susi_telegrambot/branch/development/graph/badge.svg)](https://codecov.io/gh/fossasia/susi_telegrambot)
-
 
 This is the Telegram bot for [AskSusi](https://github.com/fossasia/susi_server).
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,0 @@
-codecov:
-  branch: development
-  token: bbcdf262-a595-4c5c-9b6c-064556d70884

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node tests/sample.js && codecov"
+    "test": "node tests/sample.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
We're just testing API results, we don't have unit tests, so codecov does not work right now. We'd need Mocha / Jasmine unit tests, will add that soon.